### PR TITLE
Adding package requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,7 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.6',
+    install_requires=[
+        'requests'
+    ],
 )


### PR DESCRIPTION
tateru depends on requests so we need to reference that as a dependency in setup.py